### PR TITLE
Improve linspace to match NumPy

### DIFF
--- a/src/3arange.lisp
+++ b/src/3arange.lisp
@@ -242,7 +242,7 @@ Don't worry, we provide a compiler-macro to avoid the runtime dispatch.
 
 
 (declaim (inline linspace))
-(defun linspace (start stop num &key (endpoint t) type)
+(defun linspace (start stop &key (num 50) (endpoint t) type)
   (declare (fixnum num))
   (declare (number start stop))
   (let* ((step (/ (- stop start) (1- num)))

--- a/src/3arange.lisp
+++ b/src/3arange.lisp
@@ -253,8 +253,10 @@ Don't worry, we provide a compiler-macro to avoid the runtime dispatch.
          (lst (loop for i from 0 below (1- num)
                     for x from start by step
                     collect x))
-         (lst (if endpoint (append lst (list stop)) lst)))
-    (asarray lst :type type)))
+         (lst (if endpoint (append lst (list stop)) lst))
+         (arr (asarray lst :type type)))
+    (values arr step)))
+
 
 #+(or)
 (progn

--- a/src/3arange.lisp
+++ b/src/3arange.lisp
@@ -242,13 +242,19 @@ Don't worry, we provide a compiler-macro to avoid the runtime dispatch.
 
 
 (declaim (inline linspace))
-(defun linspace (start stop length &key type endpoint)
-  (declare (fixnum length))
-  (let* ((length (if endpoint (1+ length) length))
-         (step (/ (- stop start) length)))
-    (if type
-        (arange start stop step :type type)
-        (arange start stop step))))
+(defun linspace (start stop num &key (endpoint t) type)
+  (declare (fixnum num))
+  (declare (number start stop))
+  (let* ((step (/ (- stop start) (1- num)))
+         (type (or type (%arange-infer-type start stop step)))
+         (start (coerce start type))
+         (stop  (coerce stop  type))
+         (step  (coerce step  type))
+         (lst (loop for i from 0 below (1- num)
+                    for x from start by step
+                    collect x))
+         (lst (if endpoint (append lst (list stop)) lst)))
+    (asarray lst :type type)))
 
 #+(or)
 (progn

--- a/t/package.lisp
+++ b/t/package.lisp
@@ -62,11 +62,20 @@ NUMCL.  If not, see <http://www.gnu.org/licenses/>.
            '(array bit (5)))
   (is-type (arange 10)
            '(array (integer 0 10) (10)))
+  (is-type (linspace 1 10 10)
+           '(array (integer 0 10) (10)))
 
   (let ((a (arange 100)))
     (is-false (eq a (copy a)))
     (is-false (eq (copy a) (copy a)))
     (is-true  (equalp a (copy a)))))
+
+(test (linspace :compile-at :run-time :fixture muffle)
+  (is (equalp (linspace 2 3 5) (asarray #(2.0 2.25 2.5 2.75 3.0))))
+  (is (equalp (linspace 2 3 5 :endpoint t) (asarray #(2.0 2.25 2.5 2.75 3.0))))
+  (is (equalp (linspace 2 3 5 :endpoint nil) (asarray #(2.0 2.25 2.5 2.75))))
+  (is (equalp (linspace 2.0d0 3 5) (asarray #(2.0d0 2.25d0 2.5d0 2.75d0 3.0d0))))
+  (is (equalp (linspace 2 3 5 :type 'double-float) (asarray #(2.0d0 2.25d0 2.5d0 2.75d0 3.0d0)))))
 
 (test (aref-shape1 :compile-at :run-time :fixture muffle)
   (let* ((a (zeros '(3 4 5 6))))

--- a/t/package.lisp
+++ b/t/package.lisp
@@ -71,11 +71,11 @@ NUMCL.  If not, see <http://www.gnu.org/licenses/>.
     (is-true  (equalp a (copy a)))))
 
 (test (linspace :compile-at :run-time :fixture muffle)
-  (is (equalp (linspace 2 3 5) (asarray #(2.0 2.25 2.5 2.75 3.0))))
-  (is (equalp (linspace 2 3 5 :endpoint t) (asarray #(2.0 2.25 2.5 2.75 3.0))))
-  (is (equalp (linspace 2 3 5 :endpoint nil) (asarray #(2.0 2.25 2.5 2.75))))
-  (is (equalp (linspace 2.0d0 3 5) (asarray #(2.0d0 2.25d0 2.5d0 2.75d0 3.0d0))))
-  (is (equalp (linspace 2 3 5 :type 'double-float) (asarray #(2.0d0 2.25d0 2.5d0 2.75d0 3.0d0)))))
+  (is (equalp (linspace 2 3 5) (values (asarray #(2.0 2.25 2.5 2.75 3.0)) 0.25)))
+  (is (equalp (linspace 2 3 5 :endpoint t) (values (asarray #(2.0 2.25 2.5 2.75 3.0)) 0.25)))
+  (is (equalp (linspace 2 3 5 :endpoint nil) (values (asarray #(2.0 2.25 2.5 2.75)) 0.25)))
+  (is (equalp (linspace 2.0d0 3 5) (values (asarray #(2.0d0 2.25d0 2.5d0 2.75d0 3.0d0)) 0.25d0)))
+  (is (equalp (linspace 2 3 5 :type 'double-float) (values (asarray #(2.0d0 2.25d0 2.5d0 2.75d0 3.0d0)) 0.25d0))))
 
 (test (aref-shape1 :compile-at :run-time :fixture muffle)
   (let* ((a (zeros '(3 4 5 6))))

--- a/t/package.lisp
+++ b/t/package.lisp
@@ -71,11 +71,11 @@ NUMCL.  If not, see <http://www.gnu.org/licenses/>.
     (is-true  (equalp a (copy a)))))
 
 (test (linspace :compile-at :run-time :fixture muffle)
-  (is (equalp (linspace 2 3 5) (values (asarray #(2.0 2.25 2.5 2.75 3.0)) 0.25)))
-  (is (equalp (linspace 2 3 5 :endpoint t) (values (asarray #(2.0 2.25 2.5 2.75 3.0)) 0.25)))
-  (is (equalp (linspace 2 3 5 :endpoint nil) (values (asarray #(2.0 2.25 2.5 2.75)) 0.25)))
-  (is (equalp (linspace 2.0d0 3 5) (values (asarray #(2.0d0 2.25d0 2.5d0 2.75d0 3.0d0)) 0.25d0)))
-  (is (equalp (linspace 2 3 5 :type 'double-float) (values (asarray #(2.0d0 2.25d0 2.5d0 2.75d0 3.0d0)) 0.25d0))))
+  (is (equalp (linspace 2 3 :num 5) (values (asarray #(2.0 2.25 2.5 2.75 3.0)) 0.25)))
+  (is (equalp (linspace 2 3 :num 5 :endpoint t) (values (asarray #(2.0 2.25 2.5 2.75 3.0)) 0.25)))
+  (is (equalp (linspace 2 3 :num 5 :endpoint nil) (values (asarray #(2.0 2.25 2.5 2.75)) 0.25)))
+  (is (equalp (linspace 2.0d0 3 :num 5) (values (asarray #(2.0d0 2.25d0 2.5d0 2.75d0 3.0d0)) 0.25d0)))
+  (is (equalp (linspace 2 3 :num 5 :type 'double-float) (values (asarray #(2.0d0 2.25d0 2.5d0 2.75d0 3.0d0)) 0.25d0))))
 
 (test (aref-shape1 :compile-at :run-time :fixture muffle)
   (let* ((a (zeros '(3 4 5 6))))


### PR DESCRIPTION
Fix #49 by making `linspace` behave more like NumPy.
