### PR TITLE
Fixes issue #51

### DIFF
--- a/src/3arange.lisp
+++ b/src/3arange.lisp
@@ -32,9 +32,11 @@ NUMCL.  If not, see <http://www.gnu.org/licenses/>.
 ;; (print (arange 1 2 3))
 ;; (print (arange 1 2))
 ;; (print (arange 1))
+(declaim (inline calculate-range))  
 (defun calculate-range (start stop)
   (let* ((diff (- stop start))
-	 (inc1p (minusp (logxor stop start)))
+	 (inc1p (or (and (minusp stop) (plusp start))
+		    (and (plusp stop) (minusp start))))
 	 (pos-inc (plusp diff)))
     (cond
       ((and inc1p pos-inc) (1+ diff))

--- a/src/3arange.lisp
+++ b/src/3arange.lisp
@@ -32,10 +32,18 @@ NUMCL.  If not, see <http://www.gnu.org/licenses/>.
 ;; (print (arange 1 2 3))
 ;; (print (arange 1 2))
 ;; (print (arange 1))
+(defun calculate-range (start stop)
+  (let* ((diff (- stop start))
+	 (inc1p (minusp (logxor stop start)))
+	 (pos-inc (plusp diff)))
+    (cond
+      ((and inc1p pos-inc) (1+ diff))
+      (inc1p (1- diff))
+      (t diff))))
 
-(declaim (inline %arange))
+(declaim (inline %arange))  
 (defun %arange (start stop step type)
-  (let* ((length (max 0 (floor (- stop start) step))))
+  (let* ((length (max 0 (floor (calculate-range start stop) step))))
     (declare (fixnum length))
     (multiple-value-bind (a base) (%make-array length :element-type type)
       ;; benchnmark1 0.321 seconds


### PR DESCRIPTION
Signed-off-by: Mustafa Parlaktuna   <mparlaktuna@gmail.com>
Fixes #51 
0 was not counted during length calculation for arange. I added a calculate-range function to check the signs of start, stop and difference. Tested with the arange function calls inside example.lisp

