### PR TITLE
Fix linspace and asarray w.r.t complex values

### DIFF
--- a/src/1type.lisp
+++ b/src/1type.lisp
@@ -398,7 +398,8 @@ For an unsupported type, it signals an error.
                ((short-float-type)          'short-float)
                ;; rationals
                ((integer-subtype)           int-result)
-               ((ratio-type)                +numcl-default-float-format+)
+	       ((ratio-type)                +numcl-default-float-format+)
+	       ((rational-type)             +numcl-default-float-format+)
                ((real-subtype)              (error "this should not happen"))
                ((complex-type element-type) `(complex ,(float-substitution
                                                         element-type
@@ -442,6 +443,12 @@ This is useful for specifying the appropriate default behavior for rational func
                ((_ t) t)
                ((nil _) nil)
                ((_ nil) nil)
+	       (((complex-type t1) (complex-type t2))
+                `(complex ,(rec t1 t2)))
+               (((complex-type t1) t2)
+                `(complex ,(rec t1 t2)))
+               ((t1 (complex-type t2))
+                `(complex ,(rec t1 t2)))
                ((_ (long-float-type))   'long-float)
                (((long-float-type) _)   'long-float)
                ((_ (double-float-type)) 'double-float)
@@ -463,12 +470,6 @@ This is useful for specifying the appropriate default behavior for rational func
                ((_ (real-subtype))      (error "this should not happen"))
                (((real-subtype) _)      (error "this should not happen"))
 
-               (((complex-type t1) (complex-type t2))
-                `(complex-type ,(rec t1 t2)))
-               (((complex-type t1) t2)
-                `(complex-type ,(rec t1 t2)))
-               ((t1 (complex-type t2))
-                `(complex-type ,(rec t1 t2)))
                ;; compound types
                (((or-type types) _)
                 (rec (reduce #'rec types) t2))

--- a/t/package.lisp
+++ b/t/package.lisp
@@ -37,7 +37,7 @@ NUMCL.  If not, see <http://www.gnu.org/licenses/>.
 (def-suite :numcl)
 (in-suite :numcl)
 
-;; run test with (run! test-name) 
+;; run test with (run! 'test-name) 
 
 (defun same-base-array-p (a b)
   (match* (a b)
@@ -736,3 +736,11 @@ NUMCL.  If not, see <http://www.gnu.org/licenses/>.
   (is (alexandria:type=
        'single-float
        (numcl.impl::infer-type 'cl:* 'single-float 'bit))))
+
+(test (issue-62 :compile-at :run-time :fixture muffle)
+  (is-type (linspace 0d0 #C(9.0 9/2) :num 10)
+	   '(array (complex (double-float 0d0 9d0)) (10)))
+  
+  (is (equalp (linspace 0d0 #C(4 4) :num 5) (values (asarray #(#C(0.0d0 0.0d0) #C(1.0d0 1.0d0) #C(2.0d0 2.0d0) #C(3.0d0 3.0d0) #C(4.0d0 4.0d0))) #C(1d0 1d0))))
+
+  (is (cl:= 2 (array-rank (asarray '((#C(1 0)) (#C(1d0 5d0))))))))


### PR DESCRIPTION
Fixed up the functionality of linspace and especially asarray when creating complex arrays. Currently using this package for matrix multiplication and extraction of power-phase relationships which requires complex valued matrices. Corrects type issues of the form ((complex double-float) (0d0 10d0)) => (complex (double-float 0d0 10d0)) in multiple places. Breaks the symmetry of the other forms, but I don't know if there is a prettier way to fix it.
