### PR TITLE
convert list sequence to vector

### DIFF
--- a/src/1docstrings.lisp
+++ b/src/1docstrings.lisp
@@ -153,7 +153,7 @@ For example, `(einsum '(ij jk) a b)` is equivalent to:
  (dotimes (i <max> <output>)
    (dotimes (j <max>)
      (dotimes (k <max>)
-       (setf (aref <output> i k) (* (aref a i j) (aref b j k))))))
+       (setf (aref <output> i j k) (* (aref a i j) (aref b j k))))))
 ```
 
 # Performance

--- a/src/1docstrings.lisp
+++ b/src/1docstrings.lisp
@@ -153,7 +153,7 @@ For example, `(einsum '(ij jk) a b)` is equivalent to:
  (dotimes (i <max> <output>)
    (dotimes (j <max>)
      (dotimes (k <max>)
-       (setf (aref <output> i j k) (* (aref a i j) (aref b j k))))))
+       (setf (aref <output> i k) (* (aref a i j) (aref b j k))))))
 ```
 
 # Performance

--- a/src/1type.lisp
+++ b/src/1type.lisp
@@ -674,7 +674,8 @@ to the least specific FLOAT type when any one of them are not fixnums."
   "COERCE that additionally converts NUMBER into INTEGER by rounding, and NUMBER to (un/signed-byte N) by modular arithmetic."
   ;; wrong; could be used for char-conversions
   ;; (assert (numberp object))
-  (cond ((search "byte" (symbol-name type) :test #'equalp)
+  (cond ((and (listp type)
+	      (search "byte" (symbol-name (car type)) :from-end t :test #'equalp))
 	 #.(iter (for width from 1 to 64)
              ;; Note : This implicitly covers the case of TYPE = FIXNUM, as long as
              ;; FIXNUM bit width being below 64

--- a/src/1type.lisp
+++ b/src/1type.lisp
@@ -675,7 +675,7 @@ to the least specific FLOAT type when any one of them are not fixnums."
   ;; wrong; could be used for char-conversions
   ;; (assert (numberp object))
   (cond ((search "byte" (symbol-name type) :test #'equalp)
-	 #.(iter (for width from 1 below 64)
+	 #.(iter (for width from 1 to 64)
              ;; Note : This implicitly covers the case of TYPE = FIXNUM, as long as
              ;; FIXNUM bit width being below 64
              (when (= width 1)

--- a/src/1type.lisp
+++ b/src/1type.lisp
@@ -675,7 +675,7 @@ to the least specific FLOAT type when any one of them are not fixnums."
   ;; wrong; could be used for char-conversions
   ;; (assert (numberp object))
   (cond ((search "byte" (symbol-name type) :test #'equalp)
-	 #.(iter (for width from 1 to 64)
+	 #.(iter (for width from 1 below 64)
              ;; Note : This implicitly covers the case of TYPE = FIXNUM, as long as
              ;; FIXNUM bit width being below 64
              (when (= width 1)

--- a/src/3array.lisp
+++ b/src/3array.lisp
@@ -210,6 +210,8 @@ When TYPE is non-nil, it overrides the type deduction."
 
 (defun %nested-coerce-and-insert (base-array contents newtype level)
   (let ((index 0))
+    (if (listp contents)
+	(setf contents (coerce contents 'vector)))
     (labels ((rec (level contents)
                (if (= 0 level)
                    (setf (aref base-array index) (%coerce contents newtype)


### PR DESCRIPTION
Hi, when I test:

```common-lisp
(asarray (loop for i from 0 below 1000000
	       collect (coerce i 'double-float))
	 :type 'double-float)
``` 
It is very slow! 
so, convert list to vector , speed up!!